### PR TITLE
Remove trading session filter and align manual AI analysis

### DIFF
--- a/strategies.py
+++ b/strategies.py
@@ -172,16 +172,6 @@ class SafeStrategy(Strategy):
             print("Returning: insufficient data")
             return self._hold("insufficient data")
 
-        # Session filter with robust timestamp handling
-        print("DEBUG - df.index:", df.index)
-        print("DEBUG - df.index[-1]:", df.index[-1] if len(df.index) else None, type(df.index[-1]) if len(df.index) else None)
-
-        now_raw = self._extract_latest_ts(df)
-        now_local = self._to_session_dt(now_raw)
-        print(f"DEBUG - now_raw={now_raw!r} type={type(now_raw)}, now_local={now_local} [{self.session_zone}]")
-
-        if not self.in_session(now_raw):
-            return self._hold("outside trading session")
 
         close = df['close']
         vol = df.get('volume', pd.Series(dtype=float))


### PR DESCRIPTION
This commit includes two main changes:

1.  The trading session time filter has been removed from the `SafeStrategy`. This allows the strategy to generate trading signals at any time of day, accommodating trading for pairs that are active outside of the previous hardcoded session times.

2.  The manual 'ChatGPT Analysis' feature in the GUI has been updated to use the new AI Overseer data contract, ensuring it sends the correct payload and correctly interprets the market regime response. This aligns it with the automated trading logic.